### PR TITLE
Implement Python version of fidelius-cli

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,26 @@
+name: Tests
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.11
+
+    - name: Install dependencies
+      run: pip install .
+
+    - name: Run tests
+      run: python tests.py
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,75 @@
 pyFidelius
 ==========
+
+This is a Python port of a Java project called Fidelius-CLI https://github.com/mgrmtech/fidelius-cli/ which has utilities to generate ECDH keys based on a custom ECDSA Curve 25519 and perform encryption and decryption. Refer to the Java project's README.md for implementation details.
+
+This project uses the below two Python libraries to implement the 
+equivalent cryptographic functionalities that the Java project implements.
+
+1. [fastecdsa](https://github.com/AntonKueltz/fastecdsa) - this is used for generating public and private key pairs. This library implements the custom curve 25519 from the BouncyCastle Java library that Fidelius uses. The only difference being in the curve's `gy` parameter. We define a new custom curve named BC25519 with `gy` value taken from BouncyCastle.
+2. [pyCryptodome](https://github.com/Legrandin/pycryptodome) - this is one of the popular cryptographic libraries, used here to perform encryption and decryption following the same process as Fidelius-CLI follows.
+
+
+Installation
+============
+
+Add it as a pip-requirement in your requirements.txt and do a `pip install`.
+
+```
+fidelius @ git+https://github.com/dimagi/pyfidelius.git@master
+```
+
+Usage
+=====
+
+Generate a key pair.
+--------------------
+
+```
+from fidelius import KeyMaterial
+
+key_material = KeyMaterial.generate()
+print(key_material.private_key)
+print(key_material.public_key)
+print(key_material.x509_public_key)
+print(key_material.nonce)
+
+```
+
+Perform encryption.
+-------------------
+
+```
+from fidelius import CryptoController, EncryptionRequest
+
+encryption_request = EncryptionRequest(
+    sender_nonce="lmXgblZwotx+DfBgKJF0lZXtAXgBEYr5khh79Zytr2Y=",
+    requester_nonce="6uj1RdDUbcpI3lVMZvijkMC8Te20O4Bcyz0SyivX8Eg=",
+    sender_private_key="AYhVZpbVeX4KS5Qm/W0+9Ye2q3rnVVGmqRICmseWni4=",
+    requester_public_key="BAheD5rUqTy4V5xR4/6HWmYpopu5CO+KO8BECS0udNqUTSNo91TIqIIy1A4Vh+F94c+n9vAcwXU2bGcfsI5f69Y=",
+    string_to_encrypt="Wormtail should never have been Potter cottage's secret keeper."
+)
+controller = CryptoController()
+encrypted_string = controller.encrypt(encryption_request)
+print(encrypted_string)
+```
+
+You can also pass string_to_encrypt_base64 instead of string_to_encrypt for encrypting base64 strings
+
+Perform decryption.
+-------------------
+
+```
+from fidelius import CryptoController, DecryptionRequest
+
+decryption_request = DecryptionRequest(
+    sender_nonce="lmXgblZwotx+DfBgKJF0lZXtAXgBEYr5khh79Zytr2Y=",
+    requester_nonce="6uj1RdDUbcpI3lVMZvijkMC8Te20O4Bcyz0SyivX8Eg=",
+    requester_private_key="DMxHPri8d7IT23KgLk281zZenMfVHSdeamq0RhwlIBk=",
+    sender_public_key="BABVt+mpRLMXiQpIfEq6bj8hlXsdtXIxLsspmMgLNI1SR5mHgDVbjHO2A+U4QlMddGzqyEidzm1AkhtSxSO2Ahg=",
+    encrypted_data="pzMvVZNNVtJzqPkkxcCbBUWgDEBy/mBXIeT2dJWI16ZAQnnXUb9lI+S4k8XK6mgZSKKSRIHkcNvJpllnBg548wUgavBa0vCRRwdL6kY6Yw=="
+)
+controller = CryptoController()
+decrypted_string = controller.decrypt(decryption_request)
+print(decrypted_string)
+```

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,1 @@
+from .fidelius import *

--- a/fidelius.py
+++ b/fidelius.py
@@ -1,0 +1,192 @@
+import base64
+import os
+
+from Crypto.Protocol.KDF import HKDF
+from Crypto.Hash import SHA256
+from Crypto.Cipher import AES
+
+from dataclasses import dataclass
+from typing import Optional
+
+from fastecdsa import keys, curve, encoding
+from fastecdsa.point import Point
+
+
+# Java's Bouncycastle version of the curve 25519
+#   Only difference between BC and fastcecdsa is the value of curve.gy
+#   See https://github.com/bcgit/bc-java/blob/main/core/src/main/java/org/bouncycastle/crypto/ec/CustomNamedCurves.java#L99
+#   See the same file in below commit to find the hex decoded value of gx and gy
+#   https://github.com/bcgit/bc-java/commit/baefa5e3417c83299aa91be528aed6c23e23474c
+BC25519 = curve.Curve(
+    'BC25519',
+    curve.W25519.p,
+    curve.W25519.a,
+    curve.W25519.b,
+    curve.W25519.q,
+    curve.W25519.gx,
+    0x20ae19a1b8a086b4e01edd2c7748d14c923d4d7e6d7c61b229e9c5a27eced3d9,
+    # This is an OID specific to this implementation
+    #   taken as the next one from fastecdsa OIDs
+    b'\x01\x03\x06\x01\x04\x01\x97U\x05\x01'
+)
+
+
+class KeyMaterial:
+    def __init__(self, private_key, public_key, x509_public_key, nonce):
+        self.private_key = private_key
+        self.public_key = public_key
+        self.x509_public_key = x509_public_key
+        self.nonce = nonce
+
+    @classmethod
+    def generate(cls):
+        private_key, public_key = keys.gen_keypair(BC25519)
+        return cls._encode(private_key, public_key)
+
+    @classmethod
+    def generate_for_private_key(cls, private_key: int):
+        public_key = keys.get_public_key(private_key, BC25519)
+        return cls._encode(private_key, public_key)
+
+    @classmethod
+    def _encode(cls, private_key: int, public_key: Point):
+        private_key_base64 = cls.encode_private_key_to_base64(private_key)
+        public_key_base64 = cls.encode_public_key_to_base64(public_key)
+        x509_public_key_base64 = cls.encode_x509_public_key_to_base64(public_key)
+        nonce_base64 = cls.generate_base64_nonce()
+        return cls(private_key_base64, public_key_base64, x509_public_key_base64, nonce_base64)
+
+    @classmethod
+    def encode_private_key_to_base64(cls, key: int):
+        return base64.b64encode(
+            key.to_bytes(
+                (key.bit_length() + 7) // 8, byteorder='big'
+            )
+        ).decode('utf-8')
+
+    @classmethod
+    def encode_public_key_to_base64(cls, key: Point):
+        x_bytes = key.x.to_bytes((key.x.bit_length() + 7) // 8, byteorder='big')
+        y_bytes = key.y.to_bytes((key.y.bit_length() + 7) // 8, byteorder='big')
+        return base64.b64encode(
+            # 04 indicates uncompressed form
+            b'\x04' + x_bytes + y_bytes
+        ).decode('utf-8')
+
+    @classmethod
+    def encode_x509_public_key_to_base64(cls, key: Point):
+        # Todo: to be made compatible with java project
+        return encoding.pem.PEMEncoder().encode_public_key(key).encode()
+
+    @classmethod
+    def generate_base64_nonce(cls):
+        nonce = os.urandom(32)
+        return base64.b64encode(nonce).decode('utf-8')
+
+
+@dataclass
+class EncryptionRequest:
+    sender_nonce: str
+    requester_nonce: str
+    sender_private_key: str
+    requester_public_key: str
+    string_to_encrypt: str
+    string_to_encrypt_base64: Optional[str] = None
+
+    def __post_init__(self):
+        if self.string_to_encrypt_base64:
+            error = "Pass only one of ""string_to_encrypt or string_to_encrypt_base64"
+            assert not self.string_to_encrypt, error
+            self.string_to_encrypt = base64.b64decode(self.string_to_encrypt_base64).decode()
+
+
+@dataclass
+class DecryptionRequest:
+    sender_nonce: str
+    requester_nonce: str
+    requester_private_key: str
+    sender_public_key: str
+    encrypted_data: str
+
+
+class CryptoController:
+
+    @classmethod
+    def encrypt(cls, encryption_request: EncryptionRequest):
+        sender_nonce = base64.b64decode(encryption_request.sender_nonce)
+        requester_nonce = base64.b64decode(encryption_request.requester_nonce)
+
+        # Calculate IV and salt from nonces
+        xor_of_nonces = bytes(
+            a ^ b for a, b in zip(sender_nonce, requester_nonce)
+        )
+        iv = xor_of_nonces[-12:]
+        salt = xor_of_nonces[:20]
+
+        shared_secret = cls.compute_shared_secret(
+            encryption_request.sender_private_key,
+            encryption_request.requester_public_key
+        )
+        aes_encryption_key = cls.sha256_hkdf(salt, shared_secret, 32)
+        string_bytes = encryption_request.string_to_encrypt.encode('utf-8')
+
+        cipher = AES.new(aes_encryption_key, AES.MODE_GCM, iv)
+        encrypted_data, tag = cipher.encrypt_and_digest(string_bytes)
+        return base64.b64encode(encrypted_data + tag).decode('utf-8')
+
+    @classmethod
+    def decrypt(cls, decryption_request: DecryptionRequest):
+        sender_nonce = base64.b64decode(decryption_request.sender_nonce)
+        requester_nonce = base64.b64decode(decryption_request.requester_nonce)
+
+        # Calculate IV and salt from nonces
+        xor_of_nonces = bytes(
+            a ^ b for a, b in zip(sender_nonce, requester_nonce)
+        )
+        iv = xor_of_nonces[-12:]
+        salt = xor_of_nonces[:20]
+
+        shared_secret = cls.compute_shared_secret(
+            decryption_request.requester_private_key,
+            decryption_request.sender_public_key
+        )
+        aes_encryption_key = cls.sha256_hkdf(salt, shared_secret, 32)
+        encrypted_string = base64.b64decode(decryption_request.encrypted_data)[:-16]
+
+        cipher = AES.new(aes_encryption_key, AES.MODE_GCM, iv)
+        decrypted_string = cipher.decrypt(encrypted_string)
+
+        return decrypted_string.decode('utf-8')
+
+    @classmethod
+    def decode_base64_to_private_key(cls, encoded_key) -> int:
+        key_bytes = base64.b64decode(encoded_key.encode('utf-8'))
+        return int.from_bytes(key_bytes, byteorder='big')
+
+    @classmethod
+    def decode_base64_to_public_key(cls, encoded_key) -> Point:
+        key_bytes = base64.b64decode(encoded_key.encode('utf-8'))
+        # Ensure the key is in uncompressed form (starts with 0x04)
+        if key_bytes[0] != 0x04:
+            raise ValueError("Invalid public key format")
+        x_bytes = key_bytes[1:33]  # 32 bytes for x-coordinate
+        y_bytes = key_bytes[33:]    # 32 bytes for y-coordinate
+        x = int.from_bytes(x_bytes, byteorder='big')
+        y = int.from_bytes(y_bytes, byteorder='big')
+        return Point(x, y, curve=BC25519)
+
+    @classmethod
+    def compute_shared_secret(cls, sender_private_key, requester_public_key):
+        private_key_int = cls.decode_base64_to_private_key(sender_private_key)
+        public_key_point = cls.decode_base64_to_public_key(requester_public_key)
+        return KeyMaterial.encode_private_key_to_base64(
+            (private_key_int * public_key_point).x
+        )
+
+    @classmethod
+    def sha256_hkdf(cls, salt, shared_secret, key_length_in_bytes):
+        # Decode the initial key material from base64
+        shared_secret_bytes = base64.b64decode(shared_secret)
+        # Perform HKDF using SHA-256
+        encryption_key = HKDF(shared_secret_bytes, key_length_in_bytes, salt, SHA256)
+        return encryption_key

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,15 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='fidelius',
+    version='0.1',
+    description='A Python library for cryptographic operations',
+    author='Sravan Reddy',
+    author_email='sreddy@dimagi.com',
+    url='https://github.com/dimagi/pyFidelius',
+    py_modules=["fidelius"],
+    install_requires=[
+        'fastecdsa==2.3.0',
+        'pycryptodome==3.18.0',
+    ],
+)

--- a/tests.py
+++ b/tests.py
@@ -1,0 +1,133 @@
+import base64
+import dataclasses
+import unittest
+
+from fastecdsa import keys
+from fidelius import (
+    BC25519, KeyMaterial, CryptoController,
+    EncryptionRequest, DecryptionRequest
+)
+
+# The test keys are from Java version of fidelius-cli
+#   https://github.com/mgrmtech/fidelius-cli/blob/main/README.md
+TEST_PRIVATE_KEY = "DMxHPri8d7IT23KgLk281zZenMfVHSdeamq0RhwlIBk="
+TEST_PUBLIC_KEY = "BAheD5rUqTy4V5xR4/6HWmYpopu5CO+KO8BECS0udNqUTSNo91TIqIIy1A4Vh+F94c+n9vAcwXU2bGcfsI5f69Y="
+
+ENCRYPTION_REQUEST = EncryptionRequest(
+    sender_nonce="lmXgblZwotx+DfBgKJF0lZXtAXgBEYr5khh79Zytr2Y=",
+    requester_nonce="6uj1RdDUbcpI3lVMZvijkMC8Te20O4Bcyz0SyivX8Eg=",
+    sender_private_key="AYhVZpbVeX4KS5Qm/W0+9Ye2q3rnVVGmqRICmseWni4=",
+    requester_public_key=TEST_PUBLIC_KEY,
+    string_to_encrypt="Wormtail should never have been Potter cottage's secret keeper."
+)
+
+DECRYPTION_REQUEST = DecryptionRequest(
+    sender_nonce="lmXgblZwotx+DfBgKJF0lZXtAXgBEYr5khh79Zytr2Y=",
+    requester_nonce="6uj1RdDUbcpI3lVMZvijkMC8Te20O4Bcyz0SyivX8Eg=",
+    requester_private_key=TEST_PRIVATE_KEY,
+    sender_public_key="BABVt+mpRLMXiQpIfEq6bj8hlXsdtXIxLsspmMgLNI1SR5mHgDVbjHO2A+U4QlMddGzqyEidzm1AkhtSxSO2Ahg=",
+    encrypted_data="pzMvVZNNVtJzqPkkxcCbBUWgDEBy/mBXIeT2dJWI16ZAQnnXUb9lI+S4k8XK6mgZSKKSRIHkcNvJpllnBg548wUgavBa0vCRRwdL6kY6Yw=="
+)
+
+
+class TestUnits(unittest.TestCase):
+
+    def test_curve_BC25519(self):
+        # Test that key pair produced from BouncyCastle
+        #   Java matches the one produced by our custom
+        #   curve BC25519.
+        private_key_base64 = TEST_PRIVATE_KEY
+        private_key_int = int.from_bytes(
+            base64.b64decode(private_key_base64.encode('utf-8')),
+            byteorder='big'
+        )
+        public_key = keys.get_public_key(private_key_int, BC25519)
+        public_key_base64 = KeyMaterial.encode_public_key_to_base64(public_key)
+        self.assertEqual(
+            public_key_base64,
+            TEST_PUBLIC_KEY,
+        )
+
+    def test_private_key_encoding_decoding(self):
+        private_key_int = CryptoController.decode_base64_to_private_key(
+            TEST_PRIVATE_KEY
+        )
+        self.assertEqual(
+            private_key_int,
+            5788682699176295281730350068232349311395990232835367296300538348913375387673
+        )
+        self.assertEqual(
+            KeyMaterial.encode_private_key_to_base64(private_key_int),
+            TEST_PRIVATE_KEY
+        )
+
+    def test_public_key_encoding_decoding(self):
+        public_key_base64 = "BAheD5rUqTy4V5xR4/6HWmYpopu5CO+KO8BECS0udNqUTSNo91TIqIIy1A4Vh+F94c+n9vAcwXU2bGcfsI5f69Y="
+        public_key_point = CryptoController.decode_base64_to_public_key(
+            public_key_base64
+        )
+        self.assertEqual(
+            KeyMaterial.encode_public_key_to_base64(public_key_point),
+            public_key_base64
+        )
+
+    def test_compute_shared_secret(self):
+
+        shared_secret = CryptoController.compute_shared_secret(
+            DECRYPTION_REQUEST.requester_private_key,
+            DECRYPTION_REQUEST.sender_public_key
+        )
+        self.assertEqual(
+            shared_secret,
+            "HZbc9a4h9kMAReILN5VtvbSYHWQpfIcrZ9pWHlQZUHs="
+        )
+        self.assertEqual(
+            shared_secret,
+            CryptoController.compute_shared_secret(
+                ENCRYPTION_REQUEST.sender_private_key,
+                ENCRYPTION_REQUEST.requester_public_key
+            )
+        )
+
+
+class TestIntegration(unittest.TestCase):
+
+    def test_key_generation(self):
+        # Test that key pair generated is a valid ECDSA curve 25519 key
+        key_material = KeyMaterial.generate()
+        private_key = key_material.private_key
+        public_key = key_material.public_key
+
+        private_key_int = CryptoController.decode_base64_to_private_key(private_key)
+        public_key_point = keys.get_public_key(private_key_int, BC25519)
+        self.assertEqual(
+            KeyMaterial.encode_public_key_to_base64(public_key_point),
+            public_key
+        )
+
+    def test_encryption(self):
+        self.assertEqual(
+            CryptoController().encrypt(ENCRYPTION_REQUEST),
+            "pzMvVZNNVtJzqPkkxcCbBUWgDEBy/mBXIeT2dJWI16ZAQnnXUb9lI+S4k8XK6mgZSKKSRIHkcNvJpllnBg548wUgavBa0vCRRwdL6kY6Yw=="
+        )
+
+    def test_base64_encryption(self):
+        json_message = '{"a": "b"}'
+        base64_encryption_request = dataclasses.replace(ENCRYPTION_REQUEST)
+        base64_encryption_request.string_to_encrypt_base64 = base64.b64encode(
+            json_message.encode()
+        ).decode()
+
+        self.assertEqual(
+            CryptoController().encrypt(base64_encryption_request),
+            CryptoController().encrypt(ENCRYPTION_REQUEST)
+        )
+
+    def test_decryption(self):
+        self.assertEqual(
+            CryptoController().decrypt(DECRYPTION_REQUEST),
+            "Wormtail should never have been Potter cottage's secret keeper."
+        )
+
+
+unittest.main()


### PR DESCRIPTION
This is a Python version of the Java project https://github.com/mgrmtech/fidelius-cli

Please see [README.md](https://github.com/dimagi/pyfidelius/blob/c196b57b823640da9bb0100edf1c0da6f9786081/README.md) for implementation details.

Couple of notes.

- This doesn't implement the CLI part of the Java project as it intends to be used directly as a python package. 
- The test data uses example data/keys from the Java project to test the compatibility. 
- All operations except the x509 public key format are compatible between the two. I am planning to tackle this separately as the examples don't use this format directly for now and it seems to be a deeper rabbit hole. 
