### PR TITLE
Dependency versions updated

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     url='https://github.com/dimagi/pyFidelius',
     py_modules=["fidelius"],
     install_requires=[
-        'fastecdsa==2.3.0',
-        'pycryptodome==3.18.0',
+        'fastecdsa>=2.3.0',
+        'pycryptodome>=3.19.1',
     ],
 )


### PR DESCRIPTION

- Updated the dependencies to use minimum versions instead of exact.
- `pycryptodome` minimum version updated to `3.19.1`  as ealrlier versions have a security risk identified.